### PR TITLE
feat: add cluster version semver to cluster version provider

### DIFF
--- a/pkg/provider/k8scloudproviderprovider.go
+++ b/pkg/provider/k8scloudproviderprovider.go
@@ -43,7 +43,7 @@ func clusterProviderReport(ctx context.Context, kc kubernetes.Interface) (Report
 		if err != nil {
 			return nil, err
 		}
-		if p, ok := getClusterProviderFromVersion(cVersion); ok {
+		if p, ok := getClusterProviderFromVersion(cVersion.String()); ok {
 			return Report{
 				ClusterProviderKey: p,
 			}, nil

--- a/pkg/provider/k8sclusterversionprovider_test.go
+++ b/pkg/provider/k8sclusterversionprovider_test.go
@@ -1,0 +1,112 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	clientgo_fake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestClusterVersion(t *testing.T) {
+	testcases := []struct {
+		name       string
+		clientFunc func() *clientgo_fake.Clientset
+		expected   Report
+	}{
+		{
+			name: "undecodable git version from /version API returns the major and minor version concatenated string",
+			clientFunc: func() *clientgo_fake.Clientset {
+				kc := clientgo_fake.NewSimpleClientset()
+
+				d, ok := kc.Discovery().(*fakediscovery.FakeDiscovery)
+				require.True(t, ok)
+				d.FakedServerVersion = &version.Info{
+					Major:        "1",
+					Minor:        "24",
+					GitVersion:   "v1-custom",
+					GitCommit:    "cc6a1b4915a99f49f5510ef0667f94b9ca832a8a",
+					GitTreeState: "clean",
+					BuildDate:    "2022-06-09T18:24:04Z",
+					GoVersion:    "go1.16.15",
+					Compiler:     "gc",
+					Platform:     "linux/amd64",
+				}
+
+				return kc
+			},
+			expected: Report{
+				ClusterVersionKey:       "v1-custom",
+				ClusterVersionSemverKey: "v1.24",
+			},
+		},
+		// GKE
+		{
+			name: "gke versioning scheme is decoded properly",
+			clientFunc: func() *clientgo_fake.Clientset {
+				kc := clientgo_fake.NewSimpleClientset()
+
+				d, ok := kc.Discovery().(*fakediscovery.FakeDiscovery)
+				require.True(t, ok)
+				d.FakedServerVersion = &version.Info{
+					Major:        "1",
+					Minor:        "24",
+					GitVersion:   "v1.24.1-gke.1400",
+					GitCommit:    "206efe6f8106824435f9e408af6f49e61b30ae54",
+					GitTreeState: "clean",
+					BuildDate:    "2022-06-13T19:52:07Z",
+					GoVersion:    "go1.18.2b7",
+					Compiler:     "gc",
+					Platform:     "linux/amd64",
+				}
+
+				return kc
+			},
+			expected: Report{
+				ClusterVersionKey:       "v1.24.1-gke.1400",
+				ClusterVersionSemverKey: "v1.24.1",
+			},
+		},
+		// AWS
+		{
+			name: "aws versioning scheme is decoded properly",
+			clientFunc: func() *clientgo_fake.Clientset {
+				kc := clientgo_fake.NewSimpleClientset()
+
+				d, ok := kc.Discovery().(*fakediscovery.FakeDiscovery)
+				require.True(t, ok)
+				d.FakedServerVersion = &version.Info{
+					Major:        "1",
+					Minor:        "22+",
+					GitVersion:   "v1.22.10-eks-84b4fe6",
+					GitCommit:    "cc6a1b4915a99f49f5510ef0667f94b9ca832a8a",
+					GitTreeState: "clean",
+					BuildDate:    "2022-06-09T18:24:04Z",
+					GoVersion:    "go1.16.15",
+					Compiler:     "gc",
+					Platform:     "linux/amd64",
+				}
+
+				return kc
+			},
+			expected: Report{
+				ClusterVersionKey:       "v1.22.10-eks-84b4fe6",
+				ClusterVersionSemverKey: "v1.22.10",
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewK8sClusterVersionProvider(tc.name, tc.clientFunc())
+			require.NoError(t, err)
+
+			r, err := p.Provide(context.Background())
+			require.NoError(t, err)
+			require.EqualValues(t, tc.expected, r)
+		})
+	}
+}

--- a/pkg/telemetry/k8s.go
+++ b/pkg/telemetry/k8s.go
@@ -20,7 +20,8 @@ const (
 //
 //	{
 //	  "k8s-cluster-arch": "linux/amd64",
-//	  "k8s-cluster-version": "v1.24.1-gke.1400"
+//	  "k8s-cluster-version": "v1.24.1-gke.1400",
+//	  "k8s-cluster-version-semver": "v1.24.1",
 //	  "k8s-provider": "GKE"
 //	}
 func NewIdentifyPlatformWorkflow(kc kubernetes.Interface) (Workflow, error) {

--- a/pkg/telemetry/k8s_test.go
+++ b/pkg/telemetry/k8s_test.go
@@ -36,8 +36,9 @@ func TestWorkflowIdentifyPlatform(t *testing.T) {
 		require.EqualValues(t, provider.Report{
 			provider.ClusterArchKey: fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 			// Not really true but a reliable return value from client-go's fake client.
-			provider.ClusterVersionKey:  "v0.0.0-master+$Format:%H$",
-			provider.ClusterProviderKey: provider.ClusterProviderUnknown,
+			provider.ClusterVersionKey:       "v0.0.0-master+$Format:%H$",
+			provider.ClusterVersionSemverKey: "v0.0.0",
+			provider.ClusterProviderKey:      provider.ClusterProviderUnknown,
 		}, r)
 
 		b, err := json.Marshal(r)

--- a/pkg/telemetry/manager_test.go
+++ b/pkg/telemetry/manager_test.go
@@ -204,9 +204,10 @@ func TestManagerWithCatalogWorkflows(t *testing.T) {
 				"k8s-service-count": 2,
 			},
 			"identify-platform": provider.Report{
-				"k8s-cluster-arch":    fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-				"k8s-cluster-version": "v0.0.0-master+$Format:%H$",
-				"k8s-provider":        provider.ClusterProviderUnknown,
+				"k8s-cluster-arch":           fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+				"k8s-cluster-version":        "v0.0.0-master+$Format:%H$",
+				"k8s-cluster-version-semver": "v0.0.0",
+				"k8s-provider":               provider.ClusterProviderUnknown,
 			},
 		}, report)
 	})


### PR DESCRIPTION
This PR adds a field to cluster version provider with a parsed semver version under a key `k8s-cluster-version-semver`.

Closes #19 