### PR TITLE
feat: return partial reports without failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,11 @@ require (
 )
 
 require (
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
@@ -27,6 +32,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,6 +197,10 @@ github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/pkg/forwarders/rawchannelforwarder.go
+++ b/pkg/forwarders/rawchannelforwarder.go
@@ -1,0 +1,25 @@
+package forwarders
+
+import (
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+type rawChannelForwarder struct {
+	ch chan types.Report
+}
+
+// NewRawChannelForwarder creates new rawChannelForwarder.
+func NewRawChannelForwarder(ch chan types.Report) *rawChannelForwarder {
+	return &rawChannelForwarder{
+		ch: ch,
+	}
+}
+
+func (f *rawChannelForwarder) Name() string {
+	return "LogForwarder"
+}
+
+func (f *rawChannelForwarder) Forward(r types.Report) error {
+	f.ch <- r
+	return nil
+}

--- a/pkg/forwarders/tlsforwarder.go
+++ b/pkg/forwarders/tlsforwarder.go
@@ -7,7 +7,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/sirupsen/logrus"
+
+	"github.com/kong/kubernetes-telemetry/pkg/log"
 )
 
 const (
@@ -20,32 +21,14 @@ var tlsConf = tls.Config{
 	MaxVersion: tls.VersionTLS13,
 }
 
-// TODO: Address logging levels and library to be used.
-// See: https://github.com/Kong/kubernetes-ingress-controller/issues/1893
-const (
-	logrusrDiff = 4
-
-	// InfoLevel is the converted logging level from logrus to go-logr for
-	// information level logging. Note that the logrusr middleware technically
-	// flattens all levels prior to this level into this level as well.
-	InfoLevel = int(logrus.InfoLevel) - logrusrDiff
-
-	// DebugLevel is the converted logging level from logrus to go-logr for
-	// debug level logging.
-	DebugLevel = int(logrus.DebugLevel) - logrusrDiff
-
-	// WarnLevel is the converted logrus level to go-logr for warnings.
-	WarnLevel = int(logrus.WarnLevel) - logrusrDiff
-)
-
 type tlsForwarder struct {
-	log  logr.Logger
-	conn *tls.Conn
+	logger logr.Logger
+	conn   *tls.Conn
 }
 
 // NewTLSForwarder creates a TLS forwarder which forwards received serialized reports
 // to a TLS endpoint specified by the provided address.
-func NewTLSForwarder(address string, log logr.Logger) *tlsForwarder {
+func NewTLSForwarder(address string, logger logr.Logger) *tlsForwarder {
 	conn, err := tls.DialWithDialer(
 		&net.Dialer{
 			Timeout: defaultTimeout,
@@ -55,13 +38,13 @@ func NewTLSForwarder(address string, log logr.Logger) *tlsForwarder {
 		&tlsConf,
 	)
 	if err != nil {
-		log.V(DebugLevel).Info("failed to connect to reporting server", "error", err)
+		logger.V(log.DebugLevel).Info("failed to connect to reporting server", "error", err)
 		return nil
 	}
 
 	return &tlsForwarder{
-		log:  log,
-		conn: conn,
+		logger: logger,
+		conn:   conn,
 	}
 }
 

--- a/pkg/log/logp.go
+++ b/pkg/log/logp.go
@@ -1,0 +1,21 @@
+package log
+
+import "github.com/sirupsen/logrus"
+
+// TODO: Address logging levels and library to be used.
+// See: https://github.com/Kong/kubernetes-ingress-controller/issues/1893
+const (
+	logrusrDiff = 4
+
+	// InfoLevel is the converted logging level from logrus to go-logr for
+	// information level logging. Note that the logrusr middleware technically
+	// flattens all levels prior to this level into this level as well.
+	InfoLevel = int(logrus.InfoLevel) - logrusrDiff
+
+	// DebugLevel is the converted logging level from logrus to go-logr for
+	// debug level logging.
+	DebugLevel = int(logrus.DebugLevel) - logrusrDiff
+
+	// WarnLevel is the converted logrus level to go-logr for warnings.
+	WarnLevel = int(logrus.WarnLevel) - logrusrDiff
+)

--- a/pkg/telemetry/consumer.go
+++ b/pkg/telemetry/consumer.go
@@ -25,9 +25,10 @@ type Forwarder interface {
 // serialize the data and then forward it using the provided forwarder.
 func NewConsumer(s Serializer, f Forwarder) *consumer {
 	var (
-		ch     = make(chan types.Report)
-		done   = make(chan struct{})
-		logger = defaultLogger() // TODO: allow configuration
+		ch   = make(chan types.Report)
+		done = make(chan struct{})
+		// TODO: allow configuration: https://github.com/Kong/kubernetes-telemetry/issues/46
+		logger = defaultLogger()
 	)
 
 	go func() {
@@ -56,11 +57,69 @@ func NewConsumer(s Serializer, f Forwarder) *consumer {
 	}
 }
 
+// Intake returns a channel on which this consumer will wait for data to consume it.
 func (c *consumer) Intake() chan<- types.Report {
 	return c.ch
 }
 
+// Close closes the consumer.
 func (c *consumer) Close() {
+	c.once.Do(func() {
+		close(c.done)
+	})
+}
+
+type rawConsumer struct {
+	logger logr.Logger
+	once   sync.Once
+	ch     chan types.Report
+	done   chan struct{}
+}
+
+// RawForwarder is used to forward raw, unserialized telemetry reports to configured
+// destination(s).
+type RawForwarder interface {
+	Name() string
+	Forward(types.Report) error
+}
+
+// NewRawConsumer creates a new rawconsumer that will use the provided raw forwarder
+// to forward received reports.
+func NewRawConsumer(f RawForwarder) *rawConsumer {
+	var (
+		ch   = make(chan types.Report)
+		done = make(chan struct{})
+		// TODO: allow configuration: https://github.com/Kong/kubernetes-telemetry/issues/46
+		logger = defaultLogger()
+	)
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case r := <-ch:
+				if err := f.Forward(r); err != nil {
+					logger.Error(err, "failed to forward report using raw forwarder: %s", f.Name())
+				}
+			}
+		}
+	}()
+
+	return &rawConsumer{
+		logger: logger,
+		ch:     ch,
+		done:   done,
+	}
+}
+
+// Intake returns a channel on which this consumer will wait for data to consume it.
+func (c *rawConsumer) Intake() chan<- types.Report {
+	return c.ch
+}
+
+// Close closes rawconsumer.
+func (c *rawConsumer) Close() {
 	c.once.Do(func() {
 		close(c.done)
 	})


### PR DESCRIPTION
This PR aims to address #42 which will make the framework to return reports - even if they're partial - to the caller.

This will have the benefit of returning (and forwarding) even small traces of information instead of simply dropping it on the floor.