### PR TITLE
feat: add context to Forward()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,8 @@ require (
 
 require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )
 
@@ -36,6 +38,7 @@ require (
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/k0kubun/pp/v3 v3.1.0
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/k0kubun/pp/v3 v3.1.0 h1:ifxtqJkRZhw3h554/z/8zm6AAbyO4LLKDlA5eV+9O8Q=
+github.com/k0kubun/pp/v3 v3.1.0/go.mod h1:vIrP5CF0n78pKHm2Ku6GVerpZBJvscg48WepUYEk2gw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -231,6 +233,10 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
@@ -459,6 +465,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=

--- a/pkg/forwarders/discardforwarder.go
+++ b/pkg/forwarders/discardforwarder.go
@@ -1,5 +1,7 @@
 package forwarders
 
+import "context"
+
 type discardForwarder struct{}
 
 // NewDiscardForwarder creates a new discardForwarder which discards all received
@@ -12,6 +14,6 @@ func (df *discardForwarder) Name() string {
 	return "DiscardForwarder"
 }
 
-func (df *discardForwarder) Forward(payload []byte) error {
+func (df *discardForwarder) Forward(ctx context.Context, payload []byte) error {
 	return nil
 }

--- a/pkg/forwarders/logforwarder.go
+++ b/pkg/forwarders/logforwarder.go
@@ -1,6 +1,8 @@
 package forwarders
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
 )
 
@@ -20,7 +22,7 @@ func (lf *logForwarder) Name() string {
 	return "LogForwarder"
 }
 
-func (lf *logForwarder) Forward(payload []byte) error {
+func (lf *logForwarder) Forward(ctx context.Context, payload []byte) error {
 	lf.log.Info("got a report", "report", payload)
 	return nil
 }

--- a/pkg/forwarders/rawchannelforwarder.go
+++ b/pkg/forwarders/rawchannelforwarder.go
@@ -1,6 +1,8 @@
 package forwarders
 
 import (
+	"context"
+
 	"github.com/kong/kubernetes-telemetry/pkg/types"
 )
 
@@ -19,7 +21,12 @@ func (f *rawChannelForwarder) Name() string {
 	return "LogForwarder"
 }
 
-func (f *rawChannelForwarder) Forward(r types.Report) error {
-	f.ch <- r
+func (f *rawChannelForwarder) Forward(ctx context.Context, r types.Report) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case f.ch <- r:
+	}
+
 	return nil
 }

--- a/pkg/forwarders/tlsforwarder.go
+++ b/pkg/forwarders/tlsforwarder.go
@@ -1,6 +1,7 @@
 package forwarders
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -52,8 +53,15 @@ func (tf *tlsForwarder) Name() string {
 	return "TLSForwarder"
 }
 
-func (tf *tlsForwarder) Forward(payload []byte) error {
-	err := tf.conn.SetDeadline(time.Now().Add(defaultDeadline))
+func (tf *tlsForwarder) Forward(ctx context.Context, payload []byte) error {
+	var deadline time.Time
+	if d, ok := ctx.Deadline(); ok {
+		deadline = d
+	} else {
+		deadline = time.Now().Add(defaultDeadline)
+	}
+
+	err := tf.conn.SetDeadline(deadline)
 	if err != nil {
 		return fmt.Errorf("failed to set report connection deadline: %w", err)
 	}

--- a/pkg/provider/functorprovider.go
+++ b/pkg/provider/functorprovider.go
@@ -11,7 +11,7 @@ type functor struct {
 
 // ReportFunctor defines a function type that functor provider accepts as means
 // for delivering telemetry data.
-type ReportFunctor func() (Report, error)
+type ReportFunctor func(context.Context) (Report, error)
 
 var _ Provider = (*functor)(nil)
 
@@ -29,5 +29,5 @@ func NewFunctorProvider(name string, f ReportFunctor) (Provider, error) {
 
 // Provide returns the Report as returned by the configured functor.
 func (p *functor) Provide(ctx context.Context) (Report, error) {
-	return p.f()
+	return p.f(ctx)
 }

--- a/pkg/provider/hostnameprovider.go
+++ b/pkg/provider/hostnameprovider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"os"
 )
 
@@ -12,7 +13,7 @@ const (
 // NewHostnameProvider creates hostname provider.
 func NewHostnameProvider(name string) (Provider, error) {
 	return &functor{
-		f: func() (Report, error) {
+		f: func(ctx context.Context) (Report, error) {
 			hostname, err := os.Hostname()
 			if err != nil {
 				return nil, err

--- a/pkg/provider/uptimeprovider.go
+++ b/pkg/provider/uptimeprovider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"time"
 )
 
@@ -14,7 +15,7 @@ const (
 func NewUptimeProvider(name string) (Provider, error) {
 	start := time.Now()
 	return &functor{
-		f: func() (Report, error) {
+		f: func(ctx context.Context) (Report, error) {
 			return Report{
 				UptimeKey: int(time.Since(start).Truncate(time.Second).Seconds()),
 			}, nil

--- a/pkg/telemetry/consumer.go
+++ b/pkg/telemetry/consumer.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -12,26 +13,28 @@ type consumer struct {
 	logger logr.Logger
 	once   sync.Once
 	ch     chan types.Report
-	done   chan struct{}
+	cancel func()
 }
 
 // Forwarder is used to forward telemetry reports to configured destination(s).
 type Forwarder interface {
 	Name() string
-	Forward([]byte) error
+	Forward(context.Context, []byte) error
 }
 
 // NewConsumer creates a new consumer which will use the provided serializer to
 // serialize the data and then forward it using the provided forwarder.
 func NewConsumer(s Serializer, f Forwarder) *consumer {
 	var (
-		ch   = make(chan types.Report)
-		done = make(chan struct{})
+		ch          = make(chan types.Report)
+		ctx, cancel = context.WithCancel(context.Background())
 		// TODO: allow configuration: https://github.com/Kong/kubernetes-telemetry/issues/46
 		logger = defaultLogger()
 	)
 
 	go func() {
+		done := ctx.Done()
+
 		for {
 			select {
 			case <-done:
@@ -43,8 +46,8 @@ func NewConsumer(s Serializer, f Forwarder) *consumer {
 					continue
 				}
 
-				if err := f.Forward(b); err != nil {
-					logger.Error(err, "failed to forward report using forwarder: %s", f.Name())
+				if err := f.Forward(ctx, b); err != nil {
+					logger.Error(err, "failed to forward report", "forwarder", f.Name())
 				}
 			}
 		}
@@ -53,7 +56,7 @@ func NewConsumer(s Serializer, f Forwarder) *consumer {
 	return &consumer{
 		logger: logger,
 		ch:     ch,
-		done:   done,
+		cancel: cancel,
 	}
 }
 
@@ -65,7 +68,7 @@ func (c *consumer) Intake() chan<- types.Report {
 // Close closes the consumer.
 func (c *consumer) Close() {
 	c.once.Do(func() {
-		close(c.done)
+		c.cancel()
 	})
 }
 
@@ -73,33 +76,35 @@ type rawConsumer struct {
 	logger logr.Logger
 	once   sync.Once
 	ch     chan types.Report
-	done   chan struct{}
+	cancel func()
 }
 
 // RawForwarder is used to forward raw, unserialized telemetry reports to configured
 // destination(s).
 type RawForwarder interface {
 	Name() string
-	Forward(types.Report) error
+	Forward(context.Context, types.Report) error
 }
 
 // NewRawConsumer creates a new rawconsumer that will use the provided raw forwarder
 // to forward received reports.
 func NewRawConsumer(f RawForwarder) *rawConsumer {
 	var (
-		ch   = make(chan types.Report)
-		done = make(chan struct{})
+		ch          = make(chan types.Report)
+		ctx, cancel = context.WithCancel(context.Background())
 		// TODO: allow configuration: https://github.com/Kong/kubernetes-telemetry/issues/46
 		logger = defaultLogger()
 	)
 
 	go func() {
+		done := ctx.Done()
+
 		for {
 			select {
 			case <-done:
 				return
 			case r := <-ch:
-				if err := f.Forward(r); err != nil {
+				if err := f.Forward(ctx, r); err != nil {
 					logger.Error(err, "failed to forward report using raw forwarder: %s", f.Name())
 				}
 			}
@@ -109,7 +114,7 @@ func NewRawConsumer(f RawForwarder) *rawConsumer {
 	return &rawConsumer{
 		logger: logger,
 		ch:     ch,
-		done:   done,
+		cancel: cancel,
 	}
 }
 
@@ -121,6 +126,6 @@ func (c *rawConsumer) Intake() chan<- types.Report {
 // Close closes rawconsumer.
 func (c *rawConsumer) Close() {
 	c.once.Do(func() {
-		close(c.done)
+		c.cancel()
 	})
 }

--- a/pkg/telemetry/manager_test.go
+++ b/pkg/telemetry/manager_test.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -267,9 +268,11 @@ func TestManagerWithMultilpleWorkflowsOneReturningError(t *testing.T) {
 	{
 		w := NewWorkflow("basic_with_error")
 		{
-			p, err := provider.NewFunctorProvider("error_provider", func() (provider.Report, error) {
-				return nil, errors.New("I am an error")
-			})
+			p, err := provider.NewFunctorProvider("error_provider",
+				func(context.Context) (provider.Report, error) {
+					return nil, errors.New("I am an error")
+				},
+			)
 			require.NoError(t, err)
 			w.AddProvider(p)
 		}


### PR DESCRIPTION
This PR adds `context.Context` param to `Forward()` method so that forwarders can use it for cancelation and timeout purposes.

This does not solve the problem of long running forwarders that would not account for the `context.Context` like in e.g.

```go
provider.NewFunctorProvider("custom_functor",
	func(context.Context) (provider.Report, error) {
		time.Sleep(time.Hour)
		return provider.Report{}, nil
	},
)
```