### PR TITLE
feat: detect if CRDs for GVRs are present before adding providers for them 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.12.3
 )
 
-require github.com/hashicorp/errwrap v1.0.0 // indirect
+require (
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/provider/k8sgatewayscountprovider.go
+++ b/pkg/provider/k8sgatewayscountprovider.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
@@ -16,23 +17,11 @@ const (
 // NewK8sGatewayCountProvider creates telemetry data provider that will query the
 // configured k8s cluster - using the provided client - to get a gateway count from
 // the cluster.
-func NewK8sGatewayCountProvider(name string, d dynamic.Interface) (Provider, error) {
-	gvk := schema.GroupVersionResource{
+func NewK8sGatewayCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
 		Version:  "v1beta1",
 		Resource: "gateways",
 	}
-
-	// TODO:
-	// consider detecting what resource version is available on the cluster to
-	// properly report. Alternatively consider reporting version together with
-	// the count.
-	return &k8sObjectCount{
-		resource: d.Resource(gvk),
-		gvk:      gvk,
-		base: base{
-			name: name,
-			kind: GatewayCountKind,
-		},
-	}, nil
+	return NewK8sObjectCountProviderWithRESTMapper(name, GatewayCountKind, d, gvr, rm)
 }

--- a/pkg/provider/k8snodescountprovider.go
+++ b/pkg/provider/k8snodescountprovider.go
@@ -17,18 +17,11 @@ const (
 // configured k8s cluster - using the provided client - to get a node count from
 // the cluster.
 func NewK8sNodeCountProvider(name string, d dynamic.Interface) (Provider, error) {
-	gvk := schema.GroupVersionResource{
+	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
 		Resource: "nodes",
 	}
 
-	return &k8sObjectCount{
-		resource: d.Resource(gvk),
-		gvk:      gvk,
-		base: base{
-			name: name,
-			kind: NodeCountKind,
-		},
-	}, nil
+	return NewK8sObjectCountProvider(name, NodeCountKind, d, gvr)
 }

--- a/pkg/provider/k8sobjectcountprovider.go
+++ b/pkg/provider/k8sobjectcountprovider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -13,10 +14,41 @@ import (
 //
 // Example: Use {Group: "", Version: "v1", Resource: "pods"} to get a Provider that counts all Pods in the cluster.
 type k8sObjectCount struct {
-	gvk      schema.GroupVersionResource
+	gvr      schema.GroupVersionResource
 	resource dynamic.NamespaceableResourceInterface
 
 	base
+}
+
+// NewK8sObjectCountProvider returns a k8s object count provider, which will provide a count of
+// specified resource.
+func NewK8sObjectCountProvider(name string, kind Kind, d dynamic.Interface, gvr schema.GroupVersionResource) (Provider, error) {
+	p := &k8sObjectCount{
+		resource: d.Resource(gvr),
+		gvr:      gvr,
+		base: base{
+			name: name,
+			kind: kind,
+		},
+	}
+
+	return p, nil
+}
+
+// NewK8sObjectCountProviderWithRESTMapper returns a k8s object count provider and it will use the
+// provided rest mapper to check if there is a kind for the provided group version resource,
+// available on the cluster.
+func NewK8sObjectCountProviderWithRESTMapper(name string, kind Kind, d dynamic.Interface, gvr schema.GroupVersionResource, rm meta.RESTMapper) (Provider, error) {
+	p, err := NewK8sObjectCountProvider(name, kind, d, gvr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.(*k8sObjectCount).GVRInCluster(rm); err != nil {
+		return nil, err
+	}
+
+	return p, nil
 }
 
 const (
@@ -46,6 +78,11 @@ func (k *k8sObjectCount) Provide(ctx context.Context) (Report, error) {
 	}
 
 	return Report{
-		ReportKey("k8s_" + k.gvk.Resource + "_count"): count,
+		ReportKey("k8s_" + k.gvr.Resource + "_count"): count,
 	}, nil
+}
+
+func (k *k8sObjectCount) GVRInCluster(rm meta.RESTMapper) error {
+	_, err := rm.KindFor(k.gvr)
+	return err
 }

--- a/pkg/provider/k8spodscountprovider.go
+++ b/pkg/provider/k8spodscountprovider.go
@@ -17,18 +17,11 @@ const (
 // configured k8s cluster - using the provided client - to get a pod count from
 // the cluster.
 func NewK8sPodCountProvider(name string, d dynamic.Interface) (Provider, error) {
-	gvk := schema.GroupVersionResource{
+	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
 		Resource: "pods",
 	}
 
-	return &k8sObjectCount{
-		resource: d.Resource(gvk),
-		gvk:      gvk,
-		base: base{
-			name: name,
-			kind: PodCountKind,
-		},
-	}, nil
+	return NewK8sObjectCountProvider(name, PodCountKind, d, gvr)
 }

--- a/pkg/provider/k8sservicecountprovider.go
+++ b/pkg/provider/k8sservicecountprovider.go
@@ -17,18 +17,11 @@ const (
 // configured k8s cluster - using the provided client - to get a service count from
 // the cluster.
 func NewK8sServiceCountProvider(name string, d dynamic.Interface) (Provider, error) {
-	gvk := schema.GroupVersionResource{
+	gvr := schema.GroupVersionResource{
 		Group:    "",
 		Version:  "v1",
 		Resource: "services",
 	}
 
-	return &k8sObjectCount{
-		resource: d.Resource(gvk),
-		gvk:      gvk,
-		base: base{
-			name: name,
-			kind: ServiceCountKind,
-		},
-	}, nil
+	return NewK8sObjectCountProvider(name, ServiceCountKind, d, gvr)
 }

--- a/pkg/telemetry/workflow.go
+++ b/pkg/telemetry/workflow.go
@@ -47,6 +47,9 @@ func (w *workflow) Name() string {
 
 // AddProvider adds provider to the list of configured providers.
 func (w *workflow) AddProvider(p provider.Provider) {
+	if p == nil {
+		return
+	}
 	w.providers = append(w.providers, p)
 }
 


### PR DESCRIPTION
This PR aims to address #41. With this merged, the framework will be able to detect if a CRD for a particular GVR is available in the cluster before adding a provider (in this PR only `k8sObjectCount` is affected) which would continuously return errors like these:

```
the server could not find the requested resource
```

due to resource not having a definition available in the cluster.