### PR TITLE
feat: implement asynchronous reports triggering

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,6 +60,11 @@ linters-settings:
         alias: metav1
       - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
         alias: gateway${1}
+  revive:
+    severity: error
+    rules:
+      - name: exported
+        disabled: false
 issues:
   fix: true
   # Independently of option `exclude` we use default exclude patterns,

--- a/pkg/forwarders/channelforwader.go
+++ b/pkg/forwarders/channelforwader.go
@@ -1,0 +1,32 @@
+package forwarders
+
+import (
+	"context"
+)
+
+type channelForwarder struct {
+	ch chan []byte
+}
+
+// NewChannelForwarder creates new channelForwarder.
+func NewChannelForwarder(ch chan []byte) *channelForwarder {
+	return &channelForwarder{
+		ch: ch,
+	}
+}
+
+// Name returns the name of the forwarder.
+func (f *channelForwarder) Name() string {
+	return "channelForwarder"
+}
+
+// Forward forwards the received report on the configured channel.
+func (f *channelForwarder) Forward(ctx context.Context, r []byte) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case f.ch <- r:
+	}
+
+	return nil
+}

--- a/pkg/forwarders/discardforwarder.go
+++ b/pkg/forwarders/discardforwarder.go
@@ -10,10 +10,12 @@ func NewDiscardForwarder() *discardForwarder {
 	return &discardForwarder{}
 }
 
+// Name returns the name of the forwarder.
 func (df *discardForwarder) Name() string {
 	return "DiscardForwarder"
 }
 
+// Forward discards the received payload.
 func (df *discardForwarder) Forward(ctx context.Context, payload []byte) error {
 	return nil
 }

--- a/pkg/forwarders/logforwarder.go
+++ b/pkg/forwarders/logforwarder.go
@@ -18,10 +18,12 @@ func NewLogForwarder(log logr.Logger) *logForwarder {
 	}
 }
 
+// Name returns the name of the forwarder.
 func (lf *logForwarder) Name() string {
 	return "LogForwarder"
 }
 
+// Forward logs the received payload.
 func (lf *logForwarder) Forward(ctx context.Context, payload []byte) error {
 	lf.log.Info("got a report", "report", payload)
 	return nil

--- a/pkg/forwarders/rawchannelforwarder.go
+++ b/pkg/forwarders/rawchannelforwarder.go
@@ -7,21 +7,23 @@ import (
 )
 
 type rawChannelForwarder struct {
-	ch chan types.Report
+	ch chan types.SignalReport
 }
 
 // NewRawChannelForwarder creates new rawChannelForwarder.
-func NewRawChannelForwarder(ch chan types.Report) *rawChannelForwarder {
+func NewRawChannelForwarder(ch chan types.SignalReport) *rawChannelForwarder {
 	return &rawChannelForwarder{
 		ch: ch,
 	}
 }
 
+// Name returns the name of the forwarder.
 func (f *rawChannelForwarder) Name() string {
-	return "LogForwarder"
+	return "rawChannelForwarder"
 }
 
-func (f *rawChannelForwarder) Forward(ctx context.Context, r types.Report) error {
+// Forward forwards the received report on the configured channel.
+func (f *rawChannelForwarder) Forward(ctx context.Context, r types.SignalReport) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/pkg/forwarders/tlsforwarder.go
+++ b/pkg/forwarders/tlsforwarder.go
@@ -49,10 +49,12 @@ func NewTLSForwarder(address string, logger logr.Logger) *tlsForwarder {
 	}
 }
 
+// Name returns the name of the forwarder.
 func (tf *tlsForwarder) Name() string {
 	return "TLSForwarder"
 }
 
+// Forward forwards the received payload to the configured TLS endpoint.
 func (tf *tlsForwarder) Forward(ctx context.Context, payload []byte) error {
 	var deadline time.Time
 	if d, ok := ctx.Deadline(); ok {

--- a/pkg/serializers/semicolondelimited.go
+++ b/pkg/serializers/semicolondelimited.go
@@ -9,26 +9,22 @@ import (
 	"github.com/kong/kubernetes-telemetry/pkg/types"
 )
 
-type semicolonDelimited struct {
-	signal string
-}
+type semicolonDelimited struct{}
 
 // NewSemicolonDelimited creates a new serializer that will serialize telemetry
 // reports into a semicolon delimited format.
-func NewSemicolonDelimited(signal string) semicolonDelimited {
-	return semicolonDelimited{
-		signal: signal,
-	}
+func NewSemicolonDelimited() semicolonDelimited {
+	return semicolonDelimited{}
 }
 
-func (s semicolonDelimited) Serialize(report types.Report) ([]byte, error) {
+func (s semicolonDelimited) Serialize(report types.Report, signal types.Signal) ([]byte, error) {
 	out := make([]string, 0, len(report))
 	for _, v := range report {
 		out = append(out, serializeReport(v))
 	}
 
 	// Should this prefix go to TLSForwarder instead?
-	prefix := "<14>signal=" + s.signal + ";"
+	prefix := fmt.Sprintf("<14>signal=%s;", signal)
 
 	sort.Strings(out)
 	return []byte(prefix + strings.Join(out, "") + "\n"), nil

--- a/pkg/serializers/semicolondelimited_test.go
+++ b/pkg/serializers/semicolondelimited_test.go
@@ -12,20 +12,23 @@ import (
 
 func TestSemicolonDelimited(t *testing.T) {
 	t.Run("basic", func(t *testing.T) {
-		s := NewSemicolonDelimited("kic-ping")
+		s := NewSemicolonDelimited()
 
-		out, err := s.Serialize(types.Report{
-			"cluster-state": provider.Report{
-				"k8s_pods_count":     1,
-				"k8s_services_count": 2,
+		out, err := s.Serialize(
+			types.Report{
+				"cluster-state": provider.Report{
+					"k8s_pods_count":     1,
+					"k8s_services_count": 2,
+				},
+				"identify-platform": provider.Report{
+					"k8s_arch":     "linux/arm64",
+					"k8sv":         "v1.2.3-gke-a1fdc32f",
+					"k8sv_semver":  "v1.2.3",
+					"k8s_provider": provider.ClusterProviderGKE,
+				},
 			},
-			"identify-platform": provider.Report{
-				"k8s_arch":     "linux/arm64",
-				"k8sv":         "v1.2.3-gke-a1fdc32f",
-				"k8sv_semver":  "v1.2.3",
-				"k8s_provider": provider.ClusterProviderGKE,
-			},
-		})
+			"kic-ping",
+		)
 
 		require.NoError(t, err)
 		assert.EqualValues(t, "<14>signal=kic-ping;k8s_arch=linux/arm64;k8s_provider=GKE;k8sv=v1.2.3-gke-a1fdc32f;k8sv_semver=v1.2.3;k8s_pods_count=1;k8s_services_count=2;\n", string(out))

--- a/pkg/telemetry/serializer.go
+++ b/pkg/telemetry/serializer.go
@@ -4,5 +4,5 @@ import "github.com/kong/kubernetes-telemetry/pkg/types"
 
 // Serializer serializes telemetry reports into byte slices.
 type Serializer interface {
-	Serialize(report types.Report) ([]byte, error)
+	Serialize(report types.Report, signal types.Signal) ([]byte, error)
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -7,3 +7,12 @@ import "github.com/kong/kubernetes-telemetry/pkg/provider"
 // Report represents a report that is returned by executing managers workflows.
 // This is also the type that is being sent out to consumers.
 type Report map[string]provider.Report
+
+// Signal represents the signal name to include in the serialized report.
+type Signal string
+
+// SignalReport contains the packaged Report with a signal name attached.
+type SignalReport struct {
+	Signal
+	Report
+}


### PR DESCRIPTION
This PR aims to address #38 which allows users to trigger reports asynchronously, and to provide custom signal names at the call site.

It also adds some documentation on how to use this framework.