### PR TITLE
feat(metrics): introduce metrics for everything from Gateway API

### DIFF
--- a/pkg/provider/k8sgrpcroutescountprovider.go
+++ b/pkg/provider/k8sgrpcroutescountprovider.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// GRPCRouteCountKey is report key under which the number of GRPCRoutes in the cluster
+	// will be provided.
+	GRPCRouteCountKey = types.ProviderReportKey("k8s_grpcroutes_count")
+	// GRPCRouteCountKind represents the GRPCRoute count provider kind.
+	GRPCRouteCountKind = Kind(GRPCRouteCountKey)
+)
+
+// NewK8sGRPCRouteCountProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get a GRPCRoute count from
+// the cluster.
+func NewK8sGRPCRouteCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1alpha2",
+		Resource: "grpcroutes",
+	}
+	return NewK8sObjectCountProviderWithRESTMapper(name, GRPCRouteCountKind, d, gvr, rm)
+}

--- a/pkg/provider/k8shttproutescountprovider.go
+++ b/pkg/provider/k8shttproutescountprovider.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// HTTPRouteCountKey is report key under which the number of HTTPRoutes in the cluster
+	// will be provided.
+	HTTPRouteCountKey = types.ProviderReportKey("k8s_httproutes_count")
+	// HTTPRouteCountKind represents the HTTPRoute count provider kind.
+	HTTPRouteCountKind = Kind(HTTPRouteCountKey)
+)
+
+// NewK8sHTTPRouteCountProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get a HTTPRoute count from
+// the cluster.
+func NewK8sHTTPRouteCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1beta1",
+		Resource: "httproutes",
+	}
+	return NewK8sObjectCountProviderWithRESTMapper(name, HTTPRouteCountKind, d, gvr, rm)
+}

--- a/pkg/provider/k8sreferencegrantroutescountprovider.go
+++ b/pkg/provider/k8sreferencegrantroutescountprovider.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// ReferenceGrantCountKey is report key under which the number of ReferenceGrants in the cluster
+	// will be provided.
+	ReferenceGrantCountKey = types.ProviderReportKey("k8s_referencegrants_count")
+	// ReferenceGrantCountKind represents the ReferenceGrant count provider kind.
+	ReferenceGrantCountKind = Kind(ReferenceGrantCountKey)
+)
+
+// NewK8sReferenceGrantCountProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get a ReferenceGrant count from
+// the cluster.
+func NewK8sReferenceGrantCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1beta1",
+		Resource: "referencegrants",
+	}
+	return NewK8sObjectCountProviderWithRESTMapper(name, ReferenceGrantCountKind, d, gvr, rm)
+}

--- a/pkg/provider/k8stcproutescountprovider.go
+++ b/pkg/provider/k8stcproutescountprovider.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// TCPRouteCountKey is report key under which the number of TCPRoutes in the cluster
+	// will be provided.
+	TCPRouteCountKey = types.ProviderReportKey("k8s_tcproutes_count")
+	// TCPRouteCountKind represents the TCPRoute count provider kind.
+	TCPRouteCountKind = Kind(TCPRouteCountKey)
+)
+
+// NewK8sTCPRouteCountProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get a TCPRoute count from
+// the cluster.
+func NewK8sTCPRouteCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1alpha2",
+		Resource: "tcproutes",
+	}
+	return NewK8sObjectCountProviderWithRESTMapper(name, TCPRouteCountKind, d, gvr, rm)
+}

--- a/pkg/provider/k8stgatewayclassescountprovider.go
+++ b/pkg/provider/k8stgatewayclassescountprovider.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// GatewayClassCountKey is report key under which the number of GatewayClasses in the cluster
+	// will be provided.
+	GatewayClassCountKey = types.ProviderReportKey("k8s_gatewayclasses_count")
+	// GatewayClassCountKind represents the GatewayClass count provider kind.
+	GatewayClassCountKind = Kind(GatewayClassCountKey)
+)
+
+// NewK8sGatewayClassCountProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get a GatewayClass count from
+// the cluster.
+func NewK8sGatewayClassCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1beta1",
+		Resource: "gatewayclasses",
+	}
+	return NewK8sObjectCountProviderWithRESTMapper(name, GatewayClassCountKind, d, gvr, rm)
+}

--- a/pkg/provider/k8stlsroutescountprovider.go
+++ b/pkg/provider/k8stlsroutescountprovider.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// TLSRouteCountKey is report key under which the number of TLSRoutes in the cluster
+	// will be provided.
+	TLSRouteCountKey = types.ProviderReportKey("k8s_tlsroutes_count")
+	// TLSRouteCountKind represents the TLSRoute count provider kind.
+	TLSRouteCountKind = Kind(TLSRouteCountKey)
+)
+
+// NewK8sTLSRouteCountProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get a TLSRoute count from
+// the cluster.
+func NewK8sTLSRouteCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1alpha2",
+		Resource: "tlsroutes",
+	}
+	return NewK8sObjectCountProviderWithRESTMapper(name, TLSRouteCountKind, d, gvr, rm)
+}

--- a/pkg/provider/k8sudproutescountprovider.go
+++ b/pkg/provider/k8sudproutescountprovider.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// UDPRouteCountKey is report key under which the number of UDPRoutes in the cluster
+	// will be provided.
+	UDPRouteCountKey = types.ProviderReportKey("k8s_udproutes_count")
+	// UDPRouteCountKind represents the UDPRoute count provider kind.
+	UDPRouteCountKind = Kind(UDPRouteCountKey)
+)
+
+// NewK8sUDPRouteCountProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get a UDPRoute count from
+// the cluster.
+func NewK8sUDPRouteCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "gateway.networking.k8s.io",
+		Version:  "v1alpha2",
+		Resource: "udproutes",
+	}
+	return NewK8sObjectCountProviderWithRESTMapper(name, UDPRouteCountKind, d, gvr, rm)
+}


### PR DESCRIPTION
KTF delegates the collection of metrics to this library, thus as described in this issue https://github.com/Kong/kubernetes-ingress-controller/issues/3649 add providers to count all kinds that are in `gateway.networking.k8s.io`. They will be introduced to KTF by bumping the used version of this pkg.

