### PR TITLE
fix: don't report an error when missing Gateway API CRDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,7 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/pkg/provider/errors.go
+++ b/pkg/provider/errors.go
@@ -1,0 +1,18 @@
+package provider
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ErrGVRNotAvailable is an error which indicates that a GVR is not available.
+// It contains the reason error which can help find the root cause.
+type ErrGVRNotAvailable struct {
+	GVR    schema.GroupVersionResource
+	Reason error
+}
+
+func (e ErrGVRNotAvailable) Error() string {
+	return fmt.Sprintf("GVR %q not available, reason: %v", e.GVR, e.Reason)
+}


### PR DESCRIPTION
When running in cluster which is missing the Gateway API CRDs users may experience errors like:

```
{"level":"error","ts":"2023-06-02T16:13:45Z","logger":"setup","msg":"failed setting up anonymous reports","error":"failed to create anonymous reports manager: failed to create cluster state workflow: failed to get API group resources: unable to retrieve the complete list of server APIs: gateway.networking.k8s.io/v1beta1: the server could not find the requested resource","errorVerbose":"failed to create cluster state workflow: failed to get API group resources: unable to retrieve the complete list of server APIs: gateway.networking.k8s.io/v1beta1: the server could not find the requested resource\nfailed to create anonymous reports manager\ngithub.com/kong/gateway-operator/internal/manager.setupAnonymousReports\n\t/workspace/internal/manager/run.go:348\ngithub.com/kong/gateway-operator/internal/manager.Run\n\t/workspace/internal/manager/run.go:212\nmain.main\n\t/workspace/main.go:155\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1172","stacktrace":"github.com/kong/gateway-operator/internal/manager.Run\n\t/workspace/internal/manager/run.go:214\nmain.main\n\t/workspace/main.go:155\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:250"}
```

This PR aims to solve this by not returning an error when those CRDs are missing in the cluster and RESTMapper returns `discovery.ErrGroupDiscoveryFailed` error.

### Special notes for reviewers

The unit test that's added doesn't technically enforce the fix because 
test code uses [apimachinery restmapper](https://github.com/kubernetes/apimachinery/blob/16053f78e9258e6c227f5e704d35c67e61868d12/pkg/api/meta/restmapper.go#L360-L362) while production
code when running the operator uses the [controller runtime mapper](https://github.com/kubernetes-sigs/controller-runtime/blob/e54088c8c7da82111b4508bdaf189c45d1344f00/pkg/client/apiutil/restmapper.go#L67-L69).

I'm not aware atm how would we be able to enforce so it so just leaving this as is.
