### PR TITLE
chore(tests): refactor TestTLSForwarder - allow multiple connections

### DIFF
--- a/pkg/forwarders/tlsforwarder_test.go
+++ b/pkg/forwarders/tlsforwarder_test.go
@@ -190,6 +190,8 @@ func (ts telemetryServer) RunAndAssertExpectedData(ctx context.Context, t *testi
 // handleConnection reads data from the connection in the loop (client or error ends the connection)
 // and writes it to the channel receivedData. In case of error, it logs the error and returns.
 func handleConnection(t *testing.T, conn net.Conn, receivedData chan<- string) {
+	t.Helper()
+	
 	defer conn.Close()
 	t.Logf("server: accepted from %s", conn.RemoteAddr())
 	for {

--- a/pkg/forwarders/tlsforwarder_test.go
+++ b/pkg/forwarders/tlsforwarder_test.go
@@ -190,6 +190,8 @@ func (ts telemetryServer) RunAndAssertExpectedData(ctx context.Context, t *testi
 	ts.done <- struct{}{}
 }
 
+// handleConnection reads data from the connection in the loop (client or error ends the connection)
+// and writes it to the channel receivedData. In case of error, it logs the error and returns.
 func handleConnection(t *testing.T, conn net.Conn, receivedData chan<- string) {
 	defer conn.Close()
 	t.Logf("server: accepted from %s", conn.RemoteAddr())


### PR DESCRIPTION
Refactor `TestTLSForwarder` test, introduce mock for telemetry server that is able to handle multiple connections simultaneously and allows clients to close connections and connect again.  It doesn't rely on 
> // Accept just once because TLSForwarder persists the connection

anymore. Now it works with and without making such assumption. Relying on something like this is tricky, because network is not always reliable.

In separate PR this test will be extended to show what happens with sending telemetry when the connection is lost and the server won't be reachable for some time. 

Code related to certificates has been simplified since it wasn't tested what suppose to test according to the comment
> // Tried to actually verify the certificates in this test but was getting the following error
			// event though 127.0.0.1 and localhost were added to alt_names in openssl config:
			// failed to connect to reporting server: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs