### PR TITLE
fix: close manager's workflows loop when done

### DIFF
--- a/pkg/telemetry/manager.go
+++ b/pkg/telemetry/manager.go
@@ -201,7 +201,7 @@ func (m *manager) workflowsLoop() {
 	for {
 		select {
 		case <-m.done:
-			break
+			return
 
 		case signal := <-ch:
 			ctx, cancel := context.WithTimeout(context.Background(), m.period)


### PR DESCRIPTION
When manager's done we should exit the background workflow's loop.

There was an error where instead of exiting the loop via `break`, we would just break out of the `select` clause instead. This PR fixes it by adding a label and using it with `break`.