### PR TITLE
fix(tests): fix tlsforwarder flakiness

### DIFF
--- a/pkg/forwarders/tlsforwarder_test.go
+++ b/pkg/forwarders/tlsforwarder_test.go
@@ -63,10 +63,11 @@ func TestTLSForwarder(t *testing.T) {
 	require.NoError(t, m.Start())
 
 	require.NoError(t, m.TriggerExecute(ctx, "test-signal"))
-	require.NoError(t, m.TriggerExecute(ctx, "test-signal-2"))
-
 	assertData(ctx, t, receivedChan, []string{
 		"<14>signal=test-signal;key=value;\n",
+	})
+	require.NoError(t, m.TriggerExecute(ctx, "test-signal-2"))
+	assertData(ctx, t, receivedChan, []string{
 		"<14>signal=test-signal-2;key=value;\n",
 	})
 	require.NoError(t, telemetryServer.Close())
@@ -76,10 +77,11 @@ func TestTLSForwarder(t *testing.T) {
 	receivedChan = telemetryServer.Run(ctx, t)
 
 	require.NoError(t, m.TriggerExecute(ctx, "test-signal-3"))
-	require.NoError(t, m.TriggerExecute(ctx, "test-signal-4"))
-
 	assertData(ctx, t, receivedChan, []string{
 		"<14>signal=test-signal-3;key=value;\n",
+	})
+	require.NoError(t, m.TriggerExecute(ctx, "test-signal-4"))
+	assertData(ctx, t, receivedChan, []string{
 		"<14>signal=test-signal-4;key=value;\n",
 	})
 	require.NoError(t, telemetryServer.Close())


### PR DESCRIPTION
Because of the internal queueing of signals and reports in manager, there might situations where signals queued one after another result in respective reports coming out of the manager to be sent in different order (than the signals that triggered them).

This PR makes it so that we trigger only 1 signal and assert 1 report contents at a time to prevent these situations.

Related CI failure: https://github.com/Kong/kubernetes-telemetry/actions/runs/5266378803/jobs/9520226316#step:5:7

```
tlsforwarder_test.go:24: TLS server address 127.0.0.1:415[8](https://github.com/Kong/kubernetes-telemetry/actions/runs/5266378803/jobs/9520226316#step:5:9)5
  time="2023-06-14T11:12:21Z" level=info msg="starting telemetry manager"
      tlsforwarder_test.go:215: server: accepted from 127.0.0.1:34674
      tlsforwarder_test.go:215: server: accepted from 127.0.0.1:34686
      tlsforwarder_test.go:225: server: conn: echo "<14>signal=test-signal-2;key=value;\n"
      tlsforwarder_test.go:220: server: conn: read: EOF
      tlsforwarder_test.go:204: 
          	Error Trace:	/home/runner/work/kubernetes-telemetry/kubernetes-telemetry/pkg/forwarders/tlsforwarder_test.go:204
          	            				/home/runner/work/kubernetes-telemetry/kubernetes-telemetry/pkg/forwarders/tlsforwarder_test.go:68
          	Error:      	Not equal: 
          	            	expected: "<14>signal=test-signal;key=value;\n"
          	            	actual  : "<14>signal=test-signal-2;key=value;\n"
          	            	
          	            	Diff:
          	            	--- Expected
          	            	+++ Actual
          	            	@@ -1,2 +1,2 @@
          	            	-<14>signal=test-signal;key=value;
          	            	+<14>signal=test-signal-2;key=value;
          	            	 
          	Test:       	TestTLSForwarder
      tlsforwarder_test.go:225: server: conn: echo "<14>signal=test-signal;key=value;\n"
      tlsforwarder_test.go:220: server: conn: read: EOF
      tlsforwarder_test.go:204: 
          	Error Trace:	/home/runner/work/kubernetes-telemetry/kubernetes-telemetry/pkg/forwarders/tlsforwarder_test.go:204
          	            				/home/runner/work/kubernetes-telemetry/kubernetes-telemetry/pkg/forwarders/tlsforwarder_test.go:68
          	Error:      	Not equal: 
          	            	expected: "<14>signal=test-signal-2;key=value;\n"
          	            	actual  : "<14>signal=test-signal;key=value;\n"
          	            	
          	            	Diff:
          	            	--- Expected
          	            	+++ Actual
          	            	@@ -1,2 +1,2 @@
          	            	-<14>signal=test-signal-2;key=value;
          	            	+<14>signal=test-signal;key=value;
          	            	 
          	Test:       	TestTLSForwarder
      tlsforwarder_test.go:188: server: closed, not accepting more connections
      tlsforwarder_test.go:74: Recreate server with the same address to simulate unreliable network/server
      tlsforwarder_test.go:75: TLS server address 127.0.0.1:41585
      tlsforwarder_test.go:215: server: accepted from 127.0.0.1:34688
      tlsforwarder_test.go:215: server: accepted from 127.0.0.1:346[9](https://github.com/Kong/kubernetes-telemetry/actions/runs/5266378803/jobs/9520226316#step:5:10)4
      tlsforwarder_test.go:225: server: conn: echo "<14>signal=test-signal-3;key=value;\n"
      tlsforwarder_test.go:220: server: conn: read: EOF
      tlsforwarder_test.go:225: server: conn: echo "<[14](https://github.com/Kong/kubernetes-telemetry/actions/runs/5266378803/jobs/9520226316#step:5:15)>signal=test-signal-4;key=value;\n"
      tlsforwarder_test.go:220: server: conn: read: EOF
      tlsforwarder_test.go:[18](https://github.com/Kong/kubernetes-telemetry/actions/runs/5266378803/jobs/9520226316#step:5:19)8: server: closed, not accepting more connections
```