### PR TITLE
Add OpenShift version detector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kong/kubernetes-telemetry
 go 1.20
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/bombsimon/logrusr/v3 v3.1.0
 	github.com/gammazero/workerpool v1.1.3
 	github.com/go-logr/logr v1.2.4

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bombsimon/logrusr/v3 v3.1.0 h1:zORbLM943D+hDMGgyjMhSAz/iDz86ZV72qaak/CA0zQ=
 github.com/bombsimon/logrusr/v3 v3.1.0/go.mod h1:PksPPgSFEL2I52pla2glgCyyd2OqOHAnFF5E+g8Ixco=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/pkg/provider/openshiftversionprovider.go
+++ b/pkg/provider/openshiftversionprovider.go
@@ -37,11 +37,9 @@ func NewOpenShiftVersionProvider(name string, kc kubernetes.Interface) (Provider
 
 // openShiftVersionReport prepares a report that indicates the OpenShift version.
 func openShiftVersionReport(ctx context.Context, kc kubernetes.Interface) (types.ProviderReport, error) {
-	r := make(types.ProviderReport)
-
 	version, found := detectOpenShiftVersion(ctx, kc)
 	if !found {
-		return r, nil
+		return types.ProviderReport{}, nil
 	}
 	return osVersionReport(version), nil
 }
@@ -50,8 +48,10 @@ func openShiftVersionReport(ctx context.Context, kc kubernetes.Interface) (types
 // It returns the version (which may be empty) and a boolean indicating if the Pod was found at all. If it didn't find
 // the Pod, it's probably not OpenShift.
 func detectOpenShiftVersion(ctx context.Context, kc kubernetes.Interface) (semver.Version, bool) {
-	var pods []corev1.Pod
-	cont := ""
+	var (
+		pods []corev1.Pod
+		cont string
+	)
 	for {
 		list, err := kc.CoreV1().Pods(OpenShiftVersionPodNamespace).List(ctx, metav1.ListOptions{Continue: cont})
 		if err != nil {

--- a/pkg/provider/openshiftversionprovider.go
+++ b/pkg/provider/openshiftversionprovider.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/blang/semver/v4"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kong/kubernetes-telemetry/pkg/types"
+)
+
+const (
+	// OpenShiftVersionKey is a report key used to report the OpenShift version, if any.
+	OpenShiftVersionKey = types.ProviderReportKey("openshift_version")
+	// OpenShiftVersionKind is the OpenShift cluster version kind.
+	OpenShiftVersionKind = Kind(OpenShiftVersionKey)
+
+	// OpenShiftVersionPodNamespace is a namespace expected to contain pods whose environment includes OpenShift version
+	// information.
+	OpenShiftVersionPodNamespace = "openshift-apiserver-operator"
+	// OpenShiftVersionPodApp is a value for the "app" label to select pods whose environment includes OpenShift version
+	// information.
+	OpenShiftVersionPodApp = "openshift-apiserver-operator"
+
+	// ImageVersionVariable is the environment variable whose value contains the operator image version. For OpenShift
+	// operators, this matches the OpenShift version.
+	ImageVersionVariable = "OPERATOR_IMAGE_VERSION"
+)
+
+// NewOpenShiftVersionProvider creates telemetry data provider that will query the
+// configured k8s cluster - using the provided client - to get cluster k8s version.
+func NewOpenShiftVersionProvider(name string, kc kubernetes.Interface) (Provider, error) {
+	return NewK8sClientGoBase(name, OpenShiftVersionKind, kc, openShiftVersionReport)
+}
+
+// openShiftVersionReport prepares a report that indicates the OpenShift version.
+func openShiftVersionReport(ctx context.Context, kc kubernetes.Interface) (types.ProviderReport, error) {
+	r := make(types.ProviderReport)
+
+	version, found := detectOpenShiftVersion(ctx, kc)
+	if !found {
+		return r, nil
+	}
+	return osVersionReport(version), nil
+}
+
+// detectOpenShiftVersion checks for the presence of a known OpenShift Pod and obtains the OpenShift version from it.
+// It returns the version (which may be empty) and a boolean indicating if the Pod was found at all. If it didn't find
+// the Pod, it's probably not OpenShift.
+func detectOpenShiftVersion(ctx context.Context, kc kubernetes.Interface) (semver.Version, bool) {
+	var pods []corev1.Pod
+	cont := ""
+	for {
+		list, err := kc.CoreV1().Pods(OpenShiftVersionPodNamespace).List(ctx, metav1.ListOptions{Continue: cont})
+		if err != nil {
+			return semver.Version{}, false
+		}
+		pods = append(pods, list.Items...)
+		cont = list.Continue
+		if cont == "" {
+			break
+		}
+	}
+	for _, pod := range pods {
+		for _, ev := range pod.Spec.Containers[0].Env {
+			if ev.Name == ImageVersionVariable {
+				result, err := semver.Parse(ev.Value)
+				if err != nil {
+					return semver.Version{}, false
+				}
+				return result, true
+			}
+		}
+	}
+	return semver.Version{}, false
+}
+
+// osVersionReport transforms a semver Version into a ProviderReport containing an OpenShift version.
+func osVersionReport(version semver.Version) types.ProviderReport {
+	return types.ProviderReport{
+		OpenShiftVersionKey: version.String(),
+	}
+}

--- a/pkg/provider/openshiftversionprovider.go
+++ b/pkg/provider/openshiftversionprovider.go
@@ -29,13 +29,12 @@ const (
 	ImageVersionVariable = "OPERATOR_IMAGE_VERSION"
 )
 
-// NewOpenShiftVersionProvider creates telemetry data provider that will query the
-// configured k8s cluster - using the provided client - to get cluster k8s version.
+// NewOpenShiftVersionProvider provides the OpenShift version, or nothing if the cluster is not OpenShift.
 func NewOpenShiftVersionProvider(name string, kc kubernetes.Interface) (Provider, error) {
 	return NewK8sClientGoBase(name, OpenShiftVersionKind, kc, openShiftVersionReport)
 }
 
-// openShiftVersionReport prepares a report that indicates the OpenShift version.
+// openShiftVersionReport prepares a report that indicates the OpenShift version. It is empty on non-OpenShift clusters.
 func openShiftVersionReport(ctx context.Context, kc kubernetes.Interface) (types.ProviderReport, error) {
 	version, found := detectOpenShiftVersion(ctx, kc)
 	if !found {

--- a/pkg/telemetry/workflowsk8s.go
+++ b/pkg/telemetry/workflowsk8s.go
@@ -27,6 +27,7 @@ const (
 //	  "k8sv": "v1.24.1-gke.1400",
 //	  "k8sv_semver": "v1.24.1",
 //	  "k8s_provider": "GKE"
+//	  "openshift_version": "4.13.0"
 //	}
 func NewIdentifyPlatformWorkflow(kc kubernetes.Interface) (Workflow, error) {
 	if kc == nil {

--- a/pkg/telemetry/workflowsk8s.go
+++ b/pkg/telemetry/workflowsk8s.go
@@ -47,11 +47,16 @@ func NewIdentifyPlatformWorkflow(kc kubernetes.Interface) (Workflow, error) {
 	if err != nil {
 		return nil, err
 	}
+	pOpenShiftVersionProvider, err := provider.NewOpenShiftVersionProvider(string(provider.OpenShiftVersionKey), kc)
+	if err != nil {
+		return nil, err
+	}
 
 	w := NewWorkflow(IdentifyPlatformWorkflowName)
 	w.AddProvider(pClusterArch)
 	w.AddProvider(pClusterVersion)
 	w.AddProvider(pClusterProvider)
+	w.AddProvider(pOpenShiftVersionProvider)
 
 	return w, nil
 }


### PR DESCRIPTION
Scan a Pod for OpenShift environment variables that indicate the OpenShift cluster version.

See research in https://github.com/Kong/kubernetes-ingress-controller/issues/3149#issuecomment-1593882194. This implements the Pod environment variable option, which may be less accurate but requires no new permissions.

Confirmed able to report version on a local OpenShift 4.13 instance using https://github.com/Kong/kubernetes-ingress-controller/pull/4211:

```
signal=kic-ping;db=off;feature-combinedroutes=true;feature-combinedservices=true;feature-expressionroutes=false;feature-fillids=false;feature-gateway-service-discovery=true;feature-gateway=true;feature-gatewayalpha=false;feature-knative=false;feature-konnect-sync=false;hn=traines-test-kong-657f977554-99jf6;id=9ba8fb10-5458-4c81-a6d7-142754afbfa5;kv=3.3.0;uptime=480;v=osv.2;discovered_gateways_count=2;k8s_arch=linux/amd64;k8s_provider=UNKNOWN;k8sv=v1.26.3+b404935;k8sv_semver=v1.26.3;k8s_gatewayclasses_count=0;k8s_gateways_count=0;k8s_grpcroutes_count=0;k8s_httproutes_count=0;k8s_nodes_count=1;k8s_pods_count=74;k8s_referencegrants_count=0;k8s_services_count=65;k8s_tcproutes_count=0;k8s_tlsroutes_count=0;k8s_udproutes_count=0;mdist=all65;openshift_version=4.13.0;
```

but looking for initial review on this approach (versus other resources that require new permissions) before building out the tests.