### PR TITLE
chore(linter): in switch case default signifies exhaustive match and fix forbidigo

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,6 +36,8 @@ linters:
   - unused
   - wastedassign
 linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
   gomnd:
     ignored-numbers:
     - '2'
@@ -65,7 +67,7 @@ linters-settings:
     - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
       alias: gateway${1}
   forbidigo:
-    exclude_godoc_examples: false
+    exclude-godoc-examples: false
     forbid:
     - 'CoreV1\(\)\.Endpoints(# use DiscoveryV1 EndpointSlices API instead)?'
     - 'corev1\.Endpoint(# use DiscoveryV1 EndpointSlices API instead)?'

--- a/pkg/internal/meshdetect/detector.go
+++ b/pkg/internal/meshdetect/detector.go
@@ -234,7 +234,7 @@ func isPodSidecarInjected(meshKind MeshKind, pod *corev1.Pod) bool {
 	}
 	for _, container := range pod.Spec.Containers {
 		if container.Name == sidecarName {
-			switch meshKind { //nolint:exhaustive
+			switch meshKind {
 			case MeshKindAWSAppMesh:
 				// special judgement for AWS appmesh here:
 				// AWS appmesh uses `envoy` as sidecar name, which is a very common name.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

This PR adjusts the configuration of golangci-lint, to get rid of `//nolint:exhaustive`. It is sensible always to treat `switch` statements that include case `default` as exhaustive.

Also, it fixes a typo in forbidigo configuration.
