### PR TITLE
chore(ci): disable megacheck, exportloopref; enable loopvar, gosimple; remane gomnd to mnd

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,10 +6,10 @@ linters:
   - bodyclose
   - dogsled
   - durationcheck
+  - copyloopvar
   - errcheck
   - errorlint
   - exhaustive
-  - exportloopref
   - forbidigo
   - gci
   - gocritic
@@ -17,14 +17,14 @@ linters:
   - gofmt
   - gofumpt
   - goimports
-  - gomnd
   - gomodguard
   - gosec
+  - gosimple
   - govet
   - importas
   - ineffassign
-  - megacheck
   - misspell
+  - mnd
   - nakedret
   - nilerr
   - nolintlint
@@ -39,7 +39,7 @@ linters:
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
-  gomnd:
+  mnd:
     ignored-numbers:
     - '2'
   gci:

--- a/pkg/internal/meshdetect/detector_test.go
+++ b/pkg/internal/meshdetect/detector_test.go
@@ -311,11 +311,9 @@ func TestDetectRunUnder(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.caseName, func(t *testing.T) {
-			c := b.Build()
 			d := &Detector{
-				Client: c,
+				Client: b.Build(),
 				Pod:    tc.pod,
 				PublishService: apitypes.NamespacedName{
 					Namespace: tc.pod.Namespace,

--- a/pkg/internal/meshdetect/reports_mesh_test.go
+++ b/pkg/internal/meshdetect/reports_mesh_test.go
@@ -57,7 +57,6 @@ func TestMeshDeploymentResultsToProviderReport(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.caseName, func(t *testing.T) {
 			report := tc.results.ToProviderReport()
 			require.Equal(t, tc.expected, report)

--- a/pkg/provider/k8scloudproviderprovider.go
+++ b/pkg/provider/k8scloudproviderprovider.go
@@ -170,15 +170,15 @@ func getClusterProviderFromNodesProviderID(nodeList *corev1.NodeList) (ClusterPr
 // cluster provider from the provided cluster provider distribution.
 func getMostCommonClusterProviderFromDistribution(d clusterProviderDistribution) (ClusterProvider, bool) {
 	var (
-		top   = ClusterProviderUnknown
-		found = false
-		max   = 0
+		top     = ClusterProviderUnknown
+		found   = false
+		maximum = 0
 	)
 	for k, v := range d {
-		if v > max {
+		if v > maximum {
 			top = k
 			found = true
-			max = v
+			maximum = v
 		}
 	}
 	return top, found

--- a/pkg/provider/k8scloudproviderprovider_test.go
+++ b/pkg/provider/k8scloudproviderprovider_test.go
@@ -424,7 +424,6 @@ func TestClusterProvider(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			p, err := NewK8sClusterProviderProvider(tc.name, tc.clientFunc())
 			require.NoError(t, err)

--- a/pkg/provider/k8sclusterversionprovider_test.go
+++ b/pkg/provider/k8sclusterversionprovider_test.go
@@ -101,7 +101,6 @@ func TestClusterVersion(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			p, err := NewK8sClusterVersionProvider(tc.name, tc.clientFunc())
 			require.NoError(t, err)

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -42,7 +42,6 @@ func TestReport(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tc.r1.Merge(tc.r2)
 			require.EqualValues(t, tc.expected, tc.r1)


### PR DESCRIPTION
**What this PR does / why we need it**:

Get rid of 

```log
WARN [lintersdb] The linter named "megacheck" is deprecated. It has been split into: gosimple, staticcheck, unused. 
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
WARN The linter 'gomnd' is deprecated (since v1.58.0) due to: The linter has been renamed. Replaced by mnd. 
```

during execution of 

```
make lint
```

Since [Go 1.22](https://tip.golang.org/doc/go1.22#language) the weird behavior of variables in `for range` loops is no longer a problem. Other stuff has been adjusted according to linters suggestions 