### PR TITLE
chore: refer proper versions of GWAPI CRDs

### DIFF
--- a/pkg/provider/k8sgatewayscountprovider.go
+++ b/pkg/provider/k8sgatewayscountprovider.go
@@ -22,7 +22,7 @@ const (
 func NewK8sGatewayCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1",
 		Resource: "gateways",
 	}
 	return NewK8sObjectCountProviderWithRESTMapper(name, GatewayCountKind, d, gvr, rm)

--- a/pkg/provider/k8sgrpcroutescountprovider.go
+++ b/pkg/provider/k8sgrpcroutescountprovider.go
@@ -22,7 +22,7 @@ const (
 func NewK8sGRPCRouteCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
-		Version:  "v1alpha2",
+		Version:  "v1",
 		Resource: "grpcroutes",
 	}
 	return NewK8sObjectCountProviderWithRESTMapper(name, GRPCRouteCountKind, d, gvr, rm)

--- a/pkg/provider/k8shttproutescountprovider.go
+++ b/pkg/provider/k8shttproutescountprovider.go
@@ -22,7 +22,7 @@ const (
 func NewK8sHTTPRouteCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1",
 		Resource: "httproutes",
 	}
 	return NewK8sObjectCountProviderWithRESTMapper(name, HTTPRouteCountKind, d, gvr, rm)

--- a/pkg/provider/k8stgatewayclassescountprovider.go
+++ b/pkg/provider/k8stgatewayclassescountprovider.go
@@ -22,7 +22,7 @@ const (
 func NewK8sGatewayClassCountProvider(name string, d dynamic.Interface, rm meta.RESTMapper) (Provider, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    "gateway.networking.k8s.io",
-		Version:  "v1beta1",
+		Version:  "v1",
 		Resource: "gatewayclasses",
 	}
 	return NewK8sObjectCountProviderWithRESTMapper(name, GatewayClassCountKind, d, gvr, rm)

--- a/pkg/telemetry/manager_test.go
+++ b/pkg/telemetry/manager_test.go
@@ -19,6 +19,7 @@ import (
 	clientgo_fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlclient_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -172,6 +173,7 @@ func TestManagerWithMultilpleWorkflows(t *testing.T) {
 
 func TestManagerWithCatalogWorkflows(t *testing.T) {
 	t.Run("identify platform and cluster state", func(t *testing.T) {
+		require.NoError(t, gatewayv1.Install(scheme.Scheme))
 		require.NoError(t, gatewayv1beta1.Install(scheme.Scheme))
 		require.NoError(t, gatewayv1alpha2.Install(scheme.Scheme))
 

--- a/pkg/telemetry/workflowsk8s_test.go
+++ b/pkg/telemetry/workflowsk8s_test.go
@@ -20,6 +20,7 @@ import (
 	clientgo_fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlclient_fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -122,6 +123,7 @@ func TestWorkflowClusterState(t *testing.T) {
 	})
 
 	t.Run("properly reports cluster state", func(t *testing.T) {
+		require.NoError(t, gatewayv1.Install(scheme.Scheme))
 		require.NoError(t, gatewayv1beta1.Install(scheme.Scheme))
 		require.NoError(t, gatewayv1alpha2.Install(scheme.Scheme))
 
@@ -152,19 +154,19 @@ func TestWorkflowClusterState(t *testing.T) {
 					Name:      "srv",
 				},
 			},
-			&gatewayv1beta1.GatewayClass{
+			&gatewayv1.GatewayClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "kong",
 					Name:      "gatewayclass-1",
 				},
 			},
-			&gatewayv1beta1.Gateway{
+			&gatewayv1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "kong",
 					Name:      "gateway-1",
 				},
 			},
-			&gatewayv1beta1.HTTPRoute{
+			&gatewayv1.HTTPRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "kong",
 					Name:      "httproute-1",
@@ -176,7 +178,7 @@ func TestWorkflowClusterState(t *testing.T) {
 					Name:      "referencegrant-1",
 				},
 			},
-			&gatewayv1alpha2.GRPCRoute{
+			&gatewayv1.GRPCRoute{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "kong",
 					Name:      "grpcroute-1",
@@ -272,11 +274,11 @@ func TestWorkflowClusterState(t *testing.T) {
 				meta.RESTScopeRoot,
 			)
 		}
-		as(gatewayv1beta1.GroupVersion, "GatewayClass", "gatewayclasses")
-		as(gatewayv1beta1.GroupVersion, "Gateway", "gateways")
-		as(gatewayv1beta1.GroupVersion, "HTTPRoute", "httproutes")
+		as(gatewayv1.GroupVersion, "GatewayClass", "gatewayclasses")
+		as(gatewayv1.GroupVersion, "Gateway", "gateways")
+		as(gatewayv1.GroupVersion, "HTTPRoute", "httproutes")
+		as(gatewayv1.GroupVersion, "GRPCRoute", "grpcroutes")
 		as(gatewayv1beta1.GroupVersion, "ReferenceGrant", "referencegrants")
-		as(gatewayv1alpha2.GroupVersion, "GRPCRoute", "grpcroutes")
 		as(gatewayv1alpha2.GroupVersion, "TCPRoute", "tcproutes")
 		as(gatewayv1alpha2.GroupVersion, "UDPRoute", "udproutes")
 		as(gatewayv1alpha2.GroupVersion, "TLSRoute", "tlsroutes")
@@ -293,7 +295,7 @@ func TestWorkflowClusterState(t *testing.T) {
 			map[schema.GroupVersionResource]string{
 				{
 					Group:    "gateway.networking.k8s.io",
-					Version:  "v1beta1",
+					Version:  "v1",
 					Resource: "gateways",
 				}: "GatewayList",
 			},
@@ -312,17 +314,17 @@ func TestWorkflowClusterState(t *testing.T) {
 			provider.NodeCountKey:    2,
 			provider.PodCountKey:     1,
 			provider.ServiceCountKey: 2,
-			// gateway.networking.k8s.io v1beta1
+			// gateway.networking.k8s.io v1
+			provider.GRPCRouteCountKey:    1,
+			provider.HTTPRouteCountKey:    1,
 			provider.GatewayClassCountKey: 1,
-			// This should be equal to 1 but see above for comment explaining the issue.
-			provider.GatewayCountKey:        0,
-			provider.HTTPRouteCountKey:      1,
+			provider.GatewayCountKey:      0, // This should be equal to 1 but see above for comment explaining the issue.
+			// gateway.networking.k8s.io v1beta1
 			provider.ReferenceGrantCountKey: 1,
 			// gateway.networking.k8s.io v1alpha2
-			provider.GRPCRouteCountKey: 1,
-			provider.TCPRouteCountKey:  1,
-			provider.UDPRouteCountKey:  1,
-			provider.TLSRouteCountKey:  1,
+			provider.TCPRouteCountKey: 1,
+			provider.UDPRouteCountKey: 1,
+			provider.TLSRouteCountKey: 1,
 		}, r)
 	})
 


### PR DESCRIPTION
Use versions of GWAPI CRDs in `kubernetes-telemetry` that are the newest ones, because those served versions are used currently by KIC and KGO.

It fixes problems like that [KIC test/envtest.TestTelemetry](https://github.com/Kong/kubernetes-ingress-controller/actions/runs/11552292996/job/32151220177?pr=6571#step:6:873) when in our projects the newest CRDs versions are configured