### PR TITLE
fix(manager): stop consumers when the manager is done

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/puzpuzpuz/xsync/v2 v2.5.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/goleak v1.3.0
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
 	sigs.k8s.io/controller-runtime v0.21.0


### PR DESCRIPTION
This PR addresses the need to ensure that the Manager component correctly stops all registered consumers when it is stopped, by invoking their Close() methods. Additionally, it aims to verify that no goroutine  leaks occur during this process.

Fixes: #337 